### PR TITLE
login name can be different from user id even when use_email_as_login is False

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Changelog
 2.0.14 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Always try to look up what the user entered as a login name before
+  treating it as a user id.
+  [davisagli]
 
 
 2.0.13 (2013-03-17)

--- a/Products/PasswordResetTool/PasswordResetTool.py
+++ b/Products/PasswordResetTool/PasswordResetTool.py
@@ -149,12 +149,9 @@ class PasswordResetTool (UniqueObject, SimpleItem):
         or 'userid' is not in the record.
         """
         if get_member_by_login_name:
-            props = getToolByName(self, 'portal_properties').site_properties
-            if props.getProperty('use_email_as_login', False):
-                found_member = get_member_by_login_name(
-                    self, userid, raise_exceptions=False)
-                if found_member is None:
-                    raise InvalidRequestError
+            found_member = get_member_by_login_name(
+                self, userid, raise_exceptions=False)
+            if found_member is not None:
                 userid = found_member.getId()
         try:
             stored_user, expiry = self._requests[randomstring]


### PR DESCRIPTION
I have users that have UUID-based user ids and login names that are not based on the email address.

I'm trying to deal with this by looking up what the user entered as a login name first, regardless of the use_email_as_login setting, and then assume it's a userid if nothing was found.

@mauritsvanrees, does this make sense to you?
