### PR TITLE
Add userid information in reset mail

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,8 @@ Changelog
 - Amend browser.txt test to the new p.a.registry-based control panels
   (Plone 5 only).
   [timo]
+- Added userid information in reset mail (useful when the administrator resets a user password)
+  [sgeulette]
 
 
 2.1.1 (2014-10-22)

--- a/Products/PasswordResetTool/skins/PasswordReset/mail_password_template.pt
+++ b/Products/PasswordResetTool/skins/PasswordReset/mail_password_template.pt
@@ -14,9 +14,11 @@ Precedence: bulk
      tal:omit-tag=""
      tal:define="fullname python: test(member.fullname,
                  ' %s'%member.fullname, '')">
-The following link will take you to a page where you can reset your password for <span i18n:name="site_name"
+The following link will take you to a page where you can reset your password for userid '<span i18n:name="userid"
           tal:omit-tag=""
-          tal:content="portal_state/navigation_root_title" /> site:
+          tal:content="member/id" />' on '<span i18n:name="site_name"
+          tal:omit-tag=""
+          tal:content="portal_state/navigation_root_title" />' site:
 
 <span tal:content="python:here.pwreset_constructURL(reset['randomstring'])"
           tal:omit-tag=""

--- a/Products/PasswordResetTool/skins/PasswordReset/mail_password_template.pt
+++ b/Products/PasswordResetTool/skins/PasswordReset/mail_password_template.pt
@@ -3,6 +3,7 @@
                   member python:options['member'];
                   portal_state context/@@plone_portal_state;
                   view context/@@passwordreset_view;
+                  isAnon context/@@plone_portal_state/anonymous;
                   reset python:options['reset']"
 >From: <span tal:replace="structure view/encoded_mail_sender" />
 To: <span tal:replace="python:member.getProperty('email')" />
@@ -10,15 +11,22 @@ Subject: <span tal:replace="view/mail_password_subject" />
 Precedence: bulk
 
 <div i18n:domain="passwordresettool"
+     i18n:translate="mailtemplate_reset_information"
+     tal:omit-tag=""
+     tal:condition="not:isAnon">
+The site administrator asks you to reset your password for '<span i18n:name="userid"
+          tal:omit-tag=""
+          tal:content="member/id" />' userid. Your old password doesn't work anymore.
+</div>
+
+<div i18n:domain="passwordresettool"
      i18n:translate="mailtemplate_text_linkreset"
      tal:omit-tag=""
      tal:define="fullname python: test(member.fullname,
                  ' %s'%member.fullname, '')">
-The following link will take you to a page where you can reset your password for '<span i18n:name="userid"
+The following link will take you to a page where you can reset your password for <span i18n:name="site_name"
           tal:omit-tag=""
-          tal:content="member/id" />' userid on '<span i18n:name="site_name"
-          tal:omit-tag=""
-          tal:content="portal_state/navigation_root_title" />' site:
+          tal:content="portal_state/navigation_root_title" /> site:
 
 <span tal:content="python:here.pwreset_constructURL(reset['randomstring'])"
           tal:omit-tag=""
@@ -34,7 +42,8 @@ The following link will take you to a page where you can reset your password for
 
 <div i18n:domain="passwordresettool"
      i18n:translate="mailtemplate_tracking_information"
-     tal:omit-tag="">
+     tal:omit-tag=""
+     tal:condition="isAnon">
 If you didn't expect to receive this email, please ignore it. Your password has not been changed.
 Request made from IP address <span tal:define="host request/HTTP_X_FORWARDED_FOR|request/REMOTE_ADDR"
           tal:content="host"

--- a/Products/PasswordResetTool/skins/PasswordReset/mail_password_template.pt
+++ b/Products/PasswordResetTool/skins/PasswordReset/mail_password_template.pt
@@ -14,9 +14,9 @@ Precedence: bulk
      tal:omit-tag=""
      tal:define="fullname python: test(member.fullname,
                  ' %s'%member.fullname, '')">
-The following link will take you to a page where you can reset your password for userid '<span i18n:name="userid"
+The following link will take you to a page where you can reset your password for '<span i18n:name="userid"
           tal:omit-tag=""
-          tal:content="member/id" />' on '<span i18n:name="site_name"
+          tal:content="member/id" />' userid on '<span i18n:name="site_name"
           tal:omit-tag=""
           tal:content="portal_state/navigation_root_title" />' site:
 

--- a/Products/PasswordResetTool/tests/browser.txt
+++ b/Products/PasswordResetTool/tests/browser.txt
@@ -170,7 +170,7 @@ then we extract the address that lets us reset our password:
   >>> msg = quopri.decodestring(msg)
   >>> "To: jsmith@example.com" in msg
   True
-  >>> please_visit_text = "The following link will take you to a page where you can reset your password for userid 'jsmith' on 'Plone site' site:"
+  >>> please_visit_text = "The following link will take you to a page where you can reset your password for 'jsmith' userid on 'Plone site' site:"
   >>> please_visit_text in msg
   True
   >>> url_index = msg.index(please_visit_text) + len(please_visit_text)

--- a/Products/PasswordResetTool/tests/browser.txt
+++ b/Products/PasswordResetTool/tests/browser.txt
@@ -170,7 +170,7 @@ then we extract the address that lets us reset our password:
   >>> msg = quopri.decodestring(msg)
   >>> "To: jsmith@example.com" in msg
   True
-  >>> please_visit_text = "The following link will take you to a page where you can reset your password for Plone site site:"
+  >>> please_visit_text = "The following link will take you to a page where you can reset your password for userid 'jsmith' on 'Plone site' site:"
   >>> please_visit_text in msg
   True
   >>> url_index = msg.index(please_visit_text) + len(please_visit_text)

--- a/Products/PasswordResetTool/tests/browser.txt
+++ b/Products/PasswordResetTool/tests/browser.txt
@@ -72,6 +72,7 @@ What we do here:
   - Log in
   - Log out again
   - Forget our password (this is where PasswordResetTool comes in)
+  - Check if this is a soft reset (old password already works until changed)
   - Read the e-mail that contains the URL we visit to reset our password
   - Reset our password
   - Log in with our new password
@@ -154,6 +155,24 @@ password`` in the login form:
   >>> form.getControl(name='userid').value = 'jsmith'
   >>> form.submit()
 
+We check if the old password always works.
+
+  >>> browser.open('http://nohost/plone/login')
+  >>> browser.getControl(name='__ac_name').value = 'jsmith'
+  >>> browser.getControl(name='__ac_password').value = 'secret'
+  >>> browser.getControl(name='submit').click()
+
+We should be logged in now:
+
+  >>> "You are now logged in" in browser.contents
+  True
+
+Log out again:
+
+  >>> browser.getLink('Log out').click()
+  >>> "You are now logged out" in browser.contents
+  True
+
 As part of our test setup, we replaced the original MailHost with our
 own version.  Our version doesn't mail messages, it just collects them
 in a list called ``messages``:
@@ -170,13 +189,17 @@ then we extract the address that lets us reset our password:
   >>> msg = quopri.decodestring(msg)
   >>> "To: jsmith@example.com" in msg
   True
-  >>> please_visit_text = "The following link will take you to a page where you can reset your password for 'jsmith' userid on 'Plone site' site:"
+  >>> "The site administrator asks you to reset your password for 'jsmith' userid" in msg
+  False
+  >>> please_visit_text = "The following link will take you to a page where you can reset your password for Plone site site:"
   >>> please_visit_text in msg
   True
   >>> url_index = msg.index(please_visit_text) + len(please_visit_text)
   >>> address = msg[url_index:].strip().split()[0]
- >>> address # doctest: +ELLIPSIS
+  >>> address # doctest: +ELLIPSIS
   'http://nohost/plone/passwordreset/...'
+  >>> "If you didn't expect to receive this email" in msg
+  True
 
 Now that we have the address, we will reset our password:
 
@@ -221,6 +244,9 @@ Log out again:
   - Register a member (with send email checked???)
   - Log out
   - Log in as the new member
+  - A manager resets a user password
+  - Check if this is a hard reset (old password is changed)
+  - Check the received mail
 
 First, we want to login as the portal owner:
 
@@ -260,6 +286,56 @@ We want to logout and login as the new member:
   True
 
   >>> browser.getLink('Log out').click()
+
+Again, we want to login as the portal owner:
+
+  >>> browser.open('http://nohost/plone/login')
+  >>> browser.getControl(name='__ac_name').value = SITE_OWNER_NAME
+  >>> browser.getControl(name='__ac_password').value = SITE_OWNER_PASSWORD
+  >>> browser.getControl(name='submit').click()
+  >>> "You are now logged in" in browser.contents
+  True
+
+We navigate to the Users Overview page and reset a password user:
+
+  >>> browser.getLink('Site Setup').click()
+  >>> browser.getLink('Users and Groups').click()
+  >>> resets = browser.getControl(name='users.resetpassword:records')
+  >>> reset = resets.getControl(value='wsmith')
+  >>> reset.selected = True  
+  >>> browser.getControl(name="form.button.Modify").click()
+  >>> "Changes applied." in browser.contents
+  True
+  >>> browser.getLink('Log out').click()
+  >>> "You are now logged out" in browser.contents
+  True
+
+We check if the old password is well changed.
+
+  >>> browser.open('http://nohost/plone/login')
+  >>> browser.getControl(name='__ac_name').value = 'wsmith'
+  >>> browser.getControl(name='__ac_password').value = 'supersecret'
+  >>> browser.getControl(name='submit').click()
+
+We should not be logged in:
+
+  >>> "Login failed" in browser.contents
+  True
+
+We should have received an e-mail at this point:
+
+  >>> mailhost = layer['portal'].MailHost
+  >>> len(mailhost.messages)
+  2
+  >>> import quopri
+  >>> msg = quopri.decodestring(str(mailhost.messages[-1]))
+  >>> "The site administrator asks you to reset your password for 'wsmith' userid" in msg
+  True
+  >>> please_visit_text = "The following link will take you to a page where you can reset your password for Plone site site:"
+  >>> please_visit_text in msg
+  True
+  >>> "If you didn't expect to receive this email" in msg
+  False
 
 
 1B. User joins with e-mail validation enabled and forgets password
@@ -311,7 +387,7 @@ We should have received an e-mail at this point:
 
   >>> mailhost = layer['portal'].MailHost
   >>> len(mailhost.messages)
-  2
+  3
   >>> msg = str(mailhost.messages[-1])
 
 Now that we have the message, we want to look at its contents, and
@@ -397,7 +473,7 @@ We should have received an e-mail at this point:
 
   >>> mailhost = layer['portal'].MailHost
   >>> len(mailhost.messages)
-  3
+  4
   >>> msg = str(mailhost.messages[-1])
 
 Now that we have the message, we want to look at its contents, and


### PR DESCRIPTION
This is useful when an administrator resets a user password for a people having multiple accounts on a site. 