### PR TITLE
2.0.x Add userid information in reset mail

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,10 @@ Changelog
 2.0.18 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Replace PTC by plone.app.testing (cherry-pick of master tomgross commits)
+  [sgeulette]
+- Added userid information in reset mail (useful when the administrator resets a user password)
+  [sgeulette]
 
 
 2.0.17 (2014-09-07)

--- a/Products/PasswordResetTool/skins/PasswordReset/mail_password_template.pt
+++ b/Products/PasswordResetTool/skins/PasswordReset/mail_password_template.pt
@@ -3,6 +3,7 @@
                   member python:options['member'];
                   portal_state context/@@plone_portal_state;
                   view context/@@passwordreset_view;
+                  isAnon context/@@plone_portal_state/anonymous;
                   reset python:options['reset']"
 >From: <span tal:replace="structure view/encoded_mail_sender" />
 To: <span tal:replace="python:member.getProperty('email')" />
@@ -10,15 +11,22 @@ Subject: <span tal:replace="view/mail_password_subject" />
 Precedence: bulk
 
 <div i18n:domain="passwordresettool"
+     i18n:translate="mailtemplate_reset_information"
+     tal:omit-tag=""
+     tal:condition="not:isAnon">
+The site administrator asks you to reset your password for '<span i18n:name="userid"
+          tal:omit-tag=""
+          tal:content="member/id" />' userid. Your old password doesn't work anymore.
+</div>
+
+<div i18n:domain="passwordresettool"
      i18n:translate="mailtemplate_text_linkreset"
      tal:omit-tag=""
      tal:define="fullname python: test(member.fullname,
                  ' %s'%member.fullname, '')">
-The following link will take you to a page where you can reset your password for '<span i18n:name="userid"
+The following link will take you to a page where you can reset your password for <span i18n:name="site_name"
           tal:omit-tag=""
-          tal:content="member/id" />' userid on '<span i18n:name="site_name"
-          tal:omit-tag=""
-          tal:content="portal_state/navigation_root_title" />' site:
+          tal:content="portal_state/navigation_root_title" /> site:
 
 
 <span tal:content="python:here.pwreset_constructURL(reset['randomstring'])"
@@ -35,7 +43,8 @@ The following link will take you to a page where you can reset your password for
 
 <div i18n:domain="passwordresettool"
      i18n:translate="mailtemplate_tracking_information"
-     tal:omit-tag="">
+     tal:omit-tag=""
+     tal:condition="isAnon">
 If you didn't expect to receive this email, please ignore it. Your password has not been changed.
 Request made from IP address <span tal:define="host request/HTTP_X_FORWARDED_FOR|request/REMOTE_ADDR"
           tal:content="host"

--- a/Products/PasswordResetTool/skins/PasswordReset/mail_password_template.pt
+++ b/Products/PasswordResetTool/skins/PasswordReset/mail_password_template.pt
@@ -14,9 +14,12 @@ Precedence: bulk
      tal:omit-tag=""
      tal:define="fullname python: test(member.fullname,
                  ' %s'%member.fullname, '')">
-The following link will take you to a page where you can reset your password for <span i18n:name="site_name"
+The following link will take you to a page where you can reset your password for userid '<span i18n:name="userid"
           tal:omit-tag=""
-          tal:content="portal_state/navigation_root_title" /> site:
+          tal:content="member/id" />' on '<span i18n:name="site_name"
+          tal:omit-tag=""
+          tal:content="portal_state/navigation_root_title" />' site:
+
 
 <span tal:content="python:here.pwreset_constructURL(reset['randomstring'])"
           tal:omit-tag=""

--- a/Products/PasswordResetTool/skins/PasswordReset/mail_password_template.pt
+++ b/Products/PasswordResetTool/skins/PasswordReset/mail_password_template.pt
@@ -14,9 +14,9 @@ Precedence: bulk
      tal:omit-tag=""
      tal:define="fullname python: test(member.fullname,
                  ' %s'%member.fullname, '')">
-The following link will take you to a page where you can reset your password for userid '<span i18n:name="userid"
+The following link will take you to a page where you can reset your password for '<span i18n:name="userid"
           tal:omit-tag=""
-          tal:content="member/id" />' on '<span i18n:name="site_name"
+          tal:content="member/id" />' userid on '<span i18n:name="site_name"
           tal:omit-tag=""
           tal:content="portal_state/navigation_root_title" />' site:
 

--- a/Products/PasswordResetTool/skins/PasswordReset/mail_password_template.pt
+++ b/Products/PasswordResetTool/skins/PasswordReset/mail_password_template.pt
@@ -28,7 +28,6 @@ The following link will take you to a page where you can reset your password for
           tal:omit-tag=""
           tal:content="portal_state/navigation_root_title" /> site:
 
-
 <span tal:content="python:here.pwreset_constructURL(reset['randomstring'])"
           tal:omit-tag=""
           i18n:name="reset_url" />

--- a/Products/PasswordResetTool/tests/browser.txt
+++ b/Products/PasswordResetTool/tests/browser.txt
@@ -76,9 +76,22 @@ What we do here:
   - Reset our password
   - Log in with our new password
 
+Let's go directly to the security control panel:
+
+  >>> from plone.app.testing import SITE_OWNER_NAME, SITE_OWNER_PASSWORD
+  >>> browser.addHeader('Authorization',
+  ...                   'Basic %s:%s' % (SITE_OWNER_NAME, SITE_OWNER_PASSWORD))
+  >>> browser.open('http://nohost/plone/@@security-controlpanel')
+  >>> ctrl = browser.getControl(name="form.enable_self_reg")
+  >>> ctrl.value = "on"
+  >>> ctrl = browser.getControl(name="form.enable_user_pwd_choice")
+  >>> ctrl.value = "on"
+  >>> browser.getControl(name="form.actions.save").click()
+
 Let's join as a new user. Plone's default settings won't let the user
 type in his initial password, so we need to enable that:
 
+  >>> browser = Browser(layer['app'])
   >>> browser.open('http://nohost/plone/login')
   >>> browser.getLink('Log in').click()
   >>> browser.getControl(name='__ac_name').value = TEST_USER_NAME
@@ -86,15 +99,6 @@ type in his initial password, so we need to enable that:
   >>> browser.getControl(name='submit').click()
   >>> "You are now logged in" in browser.contents
   True
-
-Let's go directly to the security control panel:
-
-  >>> browser.open('http://nohost/plone/@@security-controlpanel')
-  >>> ctrl = browser.getControl(name="form.enable_self_reg")
-  >>> ctrl.value = "on"
-  >>> ctrl = browser.getControl(name="form.enable_user_pwd_choice")
-  >>> ctrl.value = "on"
-  >>> browser.getControl(name="form.actions.save").click()
 
 Log out again and then join:
 

--- a/Products/PasswordResetTool/tests/browser.txt
+++ b/Products/PasswordResetTool/tests/browser.txt
@@ -170,7 +170,7 @@ then we extract the address that lets us reset our password:
   >>> msg = quopri.decodestring(msg)
   >>> "To: jsmith@example.com" in msg
   True
-  >>> please_visit_text = "The following link will take you to a page where you can reset your password for userid 'jsmith' on 'Plone site' site:"
+  >>> please_visit_text = "The following link will take you to a page where you can reset your password for 'jsmith' userid on 'Plone site' site:"
   >>> please_visit_text in msg
   True
   >>> url_index = msg.index(please_visit_text) + len(please_visit_text)

--- a/Products/PasswordResetTool/tests/browser.txt
+++ b/Products/PasswordResetTool/tests/browser.txt
@@ -170,7 +170,7 @@ then we extract the address that lets us reset our password:
   >>> msg = quopri.decodestring(msg)
   >>> "To: jsmith@example.com" in msg
   True
-  >>> please_visit_text = "The following link will take you to a page where you can reset your password for Plone site site:"
+  >>> please_visit_text = "The following link will take you to a page where you can reset your password for userid 'jsmith' on 'Plone site' site:"
   >>> please_visit_text in msg
   True
   >>> url_index = msg.index(please_visit_text) + len(please_visit_text)

--- a/Products/PasswordResetTool/tests/browser.txt
+++ b/Products/PasswordResetTool/tests/browser.txt
@@ -72,6 +72,7 @@ What we do here:
   - Log in
   - Log out again
   - Forget our password (this is where PasswordResetTool comes in)
+  - Check if this is a soft reset (old password already works until changed)
   - Read the e-mail that contains the URL we visit to reset our password
   - Reset our password
   - Log in with our new password
@@ -154,6 +155,24 @@ password`` in the login form:
   >>> form.getControl(name='userid').value = 'jsmith'
   >>> form.submit()
 
+We check if the old password always works.
+
+  >>> browser.open('http://nohost/plone/login')
+  >>> browser.getControl(name='__ac_name').value = 'jsmith'
+  >>> browser.getControl(name='__ac_password').value = 'secret'
+  >>> browser.getControl(name='submit').click()
+
+We should be logged in now:
+
+  >>> "You are now logged in" in browser.contents
+  True
+
+Log out again:
+
+  >>> browser.getLink('Log out').click()
+  >>> "You are now logged out" in browser.contents
+  True
+
 As part of our test setup, we replaced the original MailHost with our
 own version.  Our version doesn't mail messages, it just collects them
 in a list called ``messages``:
@@ -170,13 +189,17 @@ then we extract the address that lets us reset our password:
   >>> msg = quopri.decodestring(msg)
   >>> "To: jsmith@example.com" in msg
   True
-  >>> please_visit_text = "The following link will take you to a page where you can reset your password for 'jsmith' userid on 'Plone site' site:"
+  >>> "The site administrator asks you to reset your password for 'jsmith' userid" in msg
+  False
+  >>> please_visit_text = "The following link will take you to a page where you can reset your password for Plone site site:"
   >>> please_visit_text in msg
   True
   >>> url_index = msg.index(please_visit_text) + len(please_visit_text)
   >>> address = msg[url_index:].strip().split()[0]
- >>> address # doctest: +ELLIPSIS
+  >>> address # doctest: +ELLIPSIS
   'http://nohost/plone/passwordreset/...'
+  >>> "If you didn't expect to receive this email" in msg
+  True
 
 Now that we have the address, we will reset our password:
 
@@ -221,6 +244,9 @@ Log out again:
   - Register a member (with send email checked???)
   - Log out
   - Log in as the new member
+  - A manager resets a user password
+  - Check if this is a hard reset (old password is changed)
+  - Check the received mail
 
 First, we want to login as the portal owner:
 
@@ -260,6 +286,56 @@ We want to logout and login as the new member:
   True
 
   >>> browser.getLink('Log out').click()
+
+Again, we want to login as the portal owner:
+
+  >>> browser.open('http://nohost/plone/login')
+  >>> browser.getControl(name='__ac_name').value = SITE_OWNER_NAME
+  >>> browser.getControl(name='__ac_password').value = SITE_OWNER_PASSWORD
+  >>> browser.getControl(name='submit').click()
+  >>> "You are now logged in" in browser.contents
+  True
+
+We navigate to the Users Overview page and reset a password user:
+
+  >>> browser.getLink('Site Setup').click()
+  >>> browser.getLink('Users and Groups').click()
+  >>> resets = browser.getControl(name='users.resetpassword:records')
+  >>> reset = resets.getControl(value='wsmith')
+  >>> reset.selected = True  
+  >>> browser.getControl(name="form.button.Modify").click()
+  >>> "Changes applied." in browser.contents
+  True
+  >>> browser.getLink('Log out').click()
+  >>> "You are now logged out" in browser.contents
+  True
+
+We check if the old password is well changed.
+
+  >>> browser.open('http://nohost/plone/login')
+  >>> browser.getControl(name='__ac_name').value = 'wsmith'
+  >>> browser.getControl(name='__ac_password').value = 'supersecret'
+  >>> browser.getControl(name='submit').click()
+
+We should not be logged in:
+
+  >>> "Login failed" in browser.contents
+  True
+
+We should have received an e-mail at this point:
+
+  >>> mailhost = layer['portal'].MailHost
+  >>> len(mailhost.messages)
+  2
+  >>> import quopri
+  >>> msg = quopri.decodestring(str(mailhost.messages[-1]))
+  >>> "The site administrator asks you to reset your password for 'wsmith' userid" in msg
+  True
+  >>> please_visit_text = "The following link will take you to a page where you can reset your password for Plone site site:"
+  >>> please_visit_text in msg
+  True
+  >>> "If you didn't expect to receive this email" in msg
+  False
 
 
 1B. User joins with e-mail validation enabled and forgets password
@@ -311,7 +387,7 @@ We should have received an e-mail at this point:
 
   >>> mailhost = layer['portal'].MailHost
   >>> len(mailhost.messages)
-  2
+  3
   >>> msg = str(mailhost.messages[-1])
 
 Now that we have the message, we want to look at its contents, and
@@ -397,7 +473,7 @@ We should have received an e-mail at this point:
 
   >>> mailhost = layer['portal'].MailHost
   >>> len(mailhost.messages)
-  3
+  4
   >>> msg = str(mailhost.messages[-1])
 
 Now that we have the message, we want to look at its contents, and

--- a/Products/PasswordResetTool/tests/browser.txt
+++ b/Products/PasswordResetTool/tests/browser.txt
@@ -8,12 +8,9 @@ Note that our usage of testbrowser is unusual and inconsistent, mostly
 because Plone forms have inconsistencies and because testbrowser makes
 assumptions that are not true for Plone forms.
 
-  >>> from Products.PloneTestCase import PloneTestCase as PTC
-  >>> from Products.Five.testbrowser import Browser
-  >>> browser = Browser()
-  >>> browser.handleErrors = False
-  >>> browser.open('http://nohost/plone/')
-
+  >>> from plone.testing.z2 import Browser
+  >>> from plone.app.testing import TEST_USER_NAME, TEST_USER_PASSWORD
+  >>> browser = Browser(layer['app'])
 
 Assumptions
 -----------
@@ -84,8 +81,8 @@ type in his initial password, so we need to enable that:
 
   >>> browser.open('http://nohost/plone/login')
   >>> browser.getLink('Log in').click()
-  >>> browser.getControl(name='__ac_name').value = PTC.portal_owner
-  >>> browser.getControl(name='__ac_password').value = PTC.default_password
+  >>> browser.getControl(name='__ac_name').value = TEST_USER_NAME
+  >>> browser.getControl(name='__ac_password').value = TEST_USER_PASSWORD
   >>> browser.getControl(name='submit').click()
   >>> "You are now logged in" in browser.contents
   True
@@ -157,7 +154,7 @@ As part of our test setup, we replaced the original MailHost with our
 own version.  Our version doesn't mail messages, it just collects them
 in a list called ``messages``:
 
-  >>> mailhost = self.portal.MailHost
+  >>> mailhost = layer['portal'].MailHost
   >>> len(mailhost.messages)
   1
   >>> msg = mailhost.messages[0]
@@ -224,8 +221,8 @@ Log out again:
 First, we want to login as the portal owner:
 
   >>> browser.open('http://nohost/plone/login')
-  >>> browser.getControl(name='__ac_name').value = PTC.portal_owner
-  >>> browser.getControl(name='__ac_password').value = PTC.default_password
+  >>> browser.getControl(name='__ac_name').value = SITE_OWNER_NAME
+  >>> browser.getControl(name='__ac_password').value = SITE_OWNER_PASSWORD
   >>> browser.getControl(name='submit').click()
   >>> "You are now logged in" in browser.contents
   True
@@ -271,8 +268,8 @@ password.
 First off, we need to set ``validate_mail`` to False:
 
   >>> browser.open('http://nohost/plone/login')
-  >>> browser.getControl(name='__ac_name').value = PTC.portal_owner
-  >>> browser.getControl(name='__ac_password').value = PTC.default_password
+  >>> browser.getControl(name='__ac_name').value = SITE_OWNER_NAME
+  >>> browser.getControl(name='__ac_password').value = SITE_OWNER_PASSWORD
   >>> browser.getControl(name='submit').click()
   >>> "You are now logged in" in browser.contents
   True
@@ -308,7 +305,7 @@ Now register:
 
 We should have received an e-mail at this point:
 
-  >>> mailhost = self.portal.MailHost
+  >>> mailhost = layer['portal'].MailHost
   >>> len(mailhost.messages)
   2
   >>> msg = str(mailhost.messages[-1])
@@ -363,10 +360,10 @@ e-mail is sent containing the URL that lets the user log in.
 
 First, we want to login as the portal owner:
 
-  >>> from Products.PloneTestCase import PloneTestCase as PTC
+  >>> from plone.app.testing import SITE_OWNER_NAME, SITE_OWNER_PASSWORD
   >>> browser.open('http://nohost/plone/login')
-  >>> browser.getControl(name='__ac_name').value = PTC.portal_owner
-  >>> browser.getControl(name='__ac_password').value = PTC.default_password
+  >>> browser.getControl(name='__ac_name').value = SITE_OWNER_NAME
+  >>> browser.getControl(name='__ac_password').value = SITE_OWNER_PASSWORD
   >>> browser.getControl(name='submit').click()
   >>> "You are now logged in" in browser.contents
   True
@@ -394,7 +391,7 @@ Now register and logout:
 
 We should have received an e-mail at this point:
 
-  >>> mailhost = self.portal.MailHost
+  >>> mailhost = layer['portal'].MailHost
   >>> len(mailhost.messages)
   3
   >>> msg = str(mailhost.messages[-1])

--- a/Products/PasswordResetTool/tests/test_doctests.py
+++ b/Products/PasswordResetTool/tests/test_doctests.py
@@ -11,6 +11,7 @@ from Acquisition import aq_base
 from Products.CMFPlone.tests.utils import MockMailHost
 from plone.app import testing
 from plone.testing import layered
+from transaction import commit
 
 OPTIONFLAGS = (doctest.ELLIPSIS |
                doctest.NORMALIZE_WHITESPACE)
@@ -20,30 +21,34 @@ class MockMailFixture(testing.PloneSandboxLayer):
     defaultBases = (testing.PLONE_FIXTURE,)
 
     def setUpPloneSite(self, portal):
-        portal._original_MailHost = self.portal.MailHost
+        portal._original_MailHost = portal.MailHost
         portal.MailHost = mailhost = MockMailHost('MailHost')
         mailhost.smtp_host = 'localhost'
         sm = getSiteManager(context=portal)
         sm.unregisterUtility(provided=IMailHost)
         sm.registerUtility(mailhost, provided=IMailHost)
         portal.email_from_address = 'test@example.com'
+        commit()
 
-#    def beforeTearDown(self):
-#        self.portal.MailHost = self.portal._original_MailHost
-#        sm = getSiteManager(context=self.portal)
-#        sm.unregisterUtility(provided=IMailHost)
-#        sm.registerUtility(aq_base(self.portal._original_MailHost), provided=IMailHost)
+    def tearDownPloneSite(self, portal):
+        portal.MailHost = portal._original_MailHost
+        sm = getSiteManager(context=portal)
+        sm.unregisterUtility(provided=IMailHost)
+        sm.registerUtility(aq_base(portal._original_MailHost), provided=IMailHost)
+
 
 MOCK_MAIL_FIXTURE = MockMailFixture()
+MM_FUNCTIONAL_TESTING = testing.FunctionalTesting(
+            bases=(MOCK_MAIL_FIXTURE,), name='PloneTestCase:Functional')
+
 
 def test_suite():
     return unittest.TestSuite((
-        doctest.DocFileSuite('browser.txt',
-                               optionflags=OPTIONFLAGS,
-                               package='Products.PasswordResetTool.tests',
-                               test_class=MockMailHostTestCase),
-        doctest.DocFileSuite('view.txt',
-                               optionflags=OPTIONFLAGS,
-                               package='Products.PasswordResetTool.tests',
-                               test_class=MockMailHostTestCase),
-        ))
+        layered(doctest.DocFileSuite('browser.txt',
+            optionflags=OPTIONFLAGS,
+            package='Products.PasswordResetTool.tests',),
+            layer=MM_FUNCTIONAL_TESTING),
+        layered(doctest.DocFileSuite('view.txt',
+            optionflags=OPTIONFLAGS,
+            package='Products.PasswordResetTool.tests',),
+            layer=MM_FUNCTIONAL_TESTING)))

--- a/Products/PasswordResetTool/tests/test_doctests.py
+++ b/Products/PasswordResetTool/tests/test_doctests.py
@@ -14,7 +14,8 @@ from plone.testing import layered
 from transaction import commit
 
 OPTIONFLAGS = (doctest.ELLIPSIS |
-               doctest.NORMALIZE_WHITESPACE)
+               doctest.NORMALIZE_WHITESPACE |
+               doctest.REPORT_ONLY_FIRST_FAILURE)
 
 class MockMailFixture(testing.PloneSandboxLayer):
 

--- a/Products/PasswordResetTool/tests/test_doctests.py
+++ b/Products/PasswordResetTool/tests/test_doctests.py
@@ -4,45 +4,45 @@ PasswordResetTool doctests
 
 import doctest
 import unittest
-from Testing.ZopeTestCase import FunctionalDocFileSuite
-from Products.PloneTestCase import PloneTestCase
 from Products.MailHost.interfaces import IMailHost
 from zope.component import getSiteManager
 from Acquisition import aq_base
 
-PloneTestCase.setupPloneSite()
-
 from Products.CMFPlone.tests.utils import MockMailHost
-
+from plone.app import testing
+from plone.testing import layered
 
 OPTIONFLAGS = (doctest.ELLIPSIS |
                doctest.NORMALIZE_WHITESPACE)
 
-class MockMailHostTestCase(PloneTestCase.FunctionalTestCase):
+class MockMailFixture(testing.PloneSandboxLayer):
 
-    def afterSetUp(self):
-        self.portal._original_MailHost = self.portal.MailHost
-        self.portal.MailHost = mailhost = MockMailHost('MailHost')
+    defaultBases = (testing.PLONE_FIXTURE,)
+
+    def setUpPloneSite(self, portal):
+        portal._original_MailHost = self.portal.MailHost
+        portal.MailHost = mailhost = MockMailHost('MailHost')
         mailhost.smtp_host = 'localhost'
-        sm = getSiteManager(context=self.portal)
+        sm = getSiteManager(context=portal)
         sm.unregisterUtility(provided=IMailHost)
         sm.registerUtility(mailhost, provided=IMailHost)
-        self.portal.email_from_address = 'test@example.com'
+        portal.email_from_address = 'test@example.com'
 
-    def beforeTearDown(self):
-        self.portal.MailHost = self.portal._original_MailHost
-        sm = getSiteManager(context=self.portal)
-        sm.unregisterUtility(provided=IMailHost)
-        sm.registerUtility(aq_base(self.portal._original_MailHost), provided=IMailHost)
+#    def beforeTearDown(self):
+#        self.portal.MailHost = self.portal._original_MailHost
+#        sm = getSiteManager(context=self.portal)
+#        sm.unregisterUtility(provided=IMailHost)
+#        sm.registerUtility(aq_base(self.portal._original_MailHost), provided=IMailHost)
 
+MOCK_MAIL_FIXTURE = MockMailFixture()
 
 def test_suite():
     return unittest.TestSuite((
-        FunctionalDocFileSuite('browser.txt',
+        doctest.DocFileSuite('browser.txt',
                                optionflags=OPTIONFLAGS,
                                package='Products.PasswordResetTool.tests',
                                test_class=MockMailHostTestCase),
-        FunctionalDocFileSuite('view.txt',
+        doctest.DocFileSuite('view.txt',
                                optionflags=OPTIONFLAGS,
                                package='Products.PasswordResetTool.tests',
                                test_class=MockMailHostTestCase),

--- a/Products/PasswordResetTool/tests/view.txt
+++ b/Products/PasswordResetTool/tests/view.txt
@@ -1,10 +1,5 @@
 Test passwordreset BrowserView 
 
-    >>> from plone.testing.z2 import Browser
-    >>> from plone.app.testing import TEST_USER_NAME, TEST_USER_PASSWORD
-    >>> browser = Browser(layer['app'])
-    >>> browser.open('http://nohost/plone/')
-
     Setup Plone email sender
 
     >>> portal = layer['portal']
@@ -14,7 +9,7 @@ Test passwordreset BrowserView
     
     Check view methods
     
-    >>> view = self.portal.restrictedTraverse('@@passwordreset_view')
+    >>> view = portal.restrictedTraverse('@@passwordreset_view')
     >>> view.encoded_mail_sender()
     '"=?utf-8?q?Old=C5=99ich_a_Bo=C5=BEena?=" <smith@example.com>'
 

--- a/Products/PasswordResetTool/tests/view.txt
+++ b/Products/PasswordResetTool/tests/view.txt
@@ -1,16 +1,16 @@
 Test passwordreset BrowserView 
 
-    >>> from Products.PloneTestCase import PloneTestCase as PTC
-    >>> from Products.Five.testbrowser import Browser
-    >>> browser = Browser()
-    >>> browser.handleErrors = False
+    >>> from plone.testing.z2 import Browser
+    >>> from plone.app.testing import TEST_USER_NAME, TEST_USER_PASSWORD
+    >>> browser = Browser(layer['app'])
     >>> browser.open('http://nohost/plone/')
 
     Setup Plone email sender
 
-    >>> self.portal.email_from_name=u'Old\u0159ich a Bo\u017eena'
-    >>> self.portal.email_from_address='smith@example.com'
-    >>> self.portal.title=u'Koko\u0159\xedn Portal'
+    >>> portal = layer['portal']
+    >>> portal.email_from_name=u'Old\u0159ich a Bo\u017eena'
+    >>> portal.email_from_address='smith@example.com'
+    >>> portal.title=u'Koko\u0159\xedn Portal'
     
     Check view methods
     

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(name='Products.PasswordResetTool',
       zip_safe=False,
       extras_require=dict(
         test=[
-            'Products.PloneTestCase',
+            'plone.app.testing',
         ]
       ),
       install_requires=[


### PR DESCRIPTION
This is useful when an administrator resets a user password for a people having multiple accounts on a site. 
Merged tomgross commits to use plone.app.testing.