### PR TITLE
Plip10359 security controlpanel

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ Changelog
 2.1.2 (unreleased)
 ------------------
 
+- Read ``use_email_as_login`` setting from the registry instead of portal
+  properties (see https://github.com/plone/Products.CMFPlone/issues/216).
+  [jcerjak]
+
 - Amend browser.txt test to the new p.a.registry-based control panels
   (Plone 5 only).
   [timo]

--- a/Products/PasswordResetTool/PasswordResetTool.py
+++ b/Products/PasswordResetTool/PasswordResetTool.py
@@ -19,7 +19,9 @@ except ImportError:
 from App.special_dtml import DTMLFile
 from AccessControl import ClassSecurityInfo
 from AccessControl import ModuleSecurityInfo
+from plone.registry.interfaces import IRegistry
 from Products.CMFCore.permissions import ManagePortal
+from Products.CMFPlone.interfaces import ISecuritySchema
 try:
     from Products.CMFPlone.RegistrationTool import get_member_by_login_name
 except ImportError:
@@ -33,6 +35,7 @@ import datetime
 import time
 import socket
 from DateTime import DateTime
+from zope.component import getUtility
 from zope.interface import implements
 
 module_security = ModuleSecurityInfo('Products.PasswordResetTool.PasswordResetTool')
@@ -346,8 +349,10 @@ class PasswordResetTool (UniqueObject, SimpleItem):
     def getValidUser(self, userid):
         """Returns the member with 'userid' if available and None otherwise."""
         if get_member_by_login_name:
-            props = getToolByName(self, 'portal_properties').site_properties
-            if props.getProperty('use_email_as_login', False):
+            registry = getUtility(IRegistry)
+            settings = registry.forInterface(ISecuritySchema, prefix='plone')
+
+            if settings.use_email_as_login:
                 return get_member_by_login_name(
                     self, userid, raise_exceptions=False)
         membertool = getToolByName(self, 'portal_membership')

--- a/Products/PasswordResetTool/skins/PasswordReset/mail_password_form.pt
+++ b/Products/PasswordResetTool/skins/PasswordReset/mail_password_form.pt
@@ -14,7 +14,7 @@
 
 <metal:main fill-slot="main"
      tal:define="global props context/@@plone_tools/properties;
-                 use_email_as_login props/site_properties/use_email_as_login|nothing;">
+                 use_email_as_login python:context.portal_registry['plone.use_email_as_login'];">
 
     <h1 class="documentFirstHeading"
         i18n:translate="heading_lost_password">Lost Password</h1>

--- a/Products/PasswordResetTool/skins/PasswordReset/pwreset_form.cpt
+++ b/Products/PasswordResetTool/skins/PasswordReset/pwreset_form.cpt
@@ -32,7 +32,7 @@
                     <div class="field"
                          tal:define="error errors/userid | nothing;
                                      site_properties context/portal_properties/site_properties;
-                                     use_email_as_login site_properties/use_email_as_login|nothing;"
+                                     use_email_as_login python:context.portal_registry['plone.use_email_as_login'];"
                          tal:attributes="class python:test(error, 'field error', 'field')"
                          tal:condition="here/portal_password_reset/checkUser | nothing">
 

--- a/Products/PasswordResetTool/skins/PasswordReset/pwreset_invalid.pt
+++ b/Products/PasswordResetTool/skins/PasswordReset/pwreset_invalid.pt
@@ -6,7 +6,7 @@
 
 <metal:main fill-slot="main"
      tal:define="site_properties context/portal_properties/site_properties;
-                 use_email_as_login site_properties/use_email_as_login|nothing;">
+                 use_email_as_login python:context.portal_registry['plone.use_email_as_login'];">
 
     <h1 class="documentFirstHeading" i18n:translate="heading_pwreset_invalid">Error setting password</h1>
 

--- a/Products/PasswordResetTool/tests/browser.txt
+++ b/Products/PasswordResetTool/tests/browser.txt
@@ -25,9 +25,9 @@ distinct password policies regarding member registration.
   B. A password is generated for the users (and an e-mail with login
      credentials is sent automatically).
 
-This policy can enabled or disabled in the ``validate_email`` property
-on the Plone Site object.  By default ``validate_email`` is enabled
-and the second policy applies.
+This policy can be enabled or disabled with the ``enable_user_pwd_choice``
+setting in the security control panel.  By default ``enable_user_pwd_choice`` is
+disabled and the second policy applies.
 
 Another aspect we have to take into account is the fact that Plone by
 default only allows Administrators to register (other) members, but allowing


### PR DESCRIPTION
Read security settings from the registry instead of portal properties. This is part of work on the security control panel migration: https://github.com/plone/Products.CMFPlone/issues/216

This should be merged along with https://github.com/plone/Products.CMFPlone/pull/362