### PR TITLE
preserve properties added by plug-ins

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Changelog
 2.0.19 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Preserve member properties added by plug-ins. [skurfer]
 
 
 2.0.18 (2015-04-04)

--- a/Products/PasswordResetTool/PasswordResetTool.py
+++ b/Products/PasswordResetTool/PasswordResetTool.py
@@ -182,7 +182,9 @@ class PasswordResetTool (UniqueObject, SimpleItem):
                 # (and stupid!) way to change a password in Zope
                 member.setSecurityProfile(password=password)
 
-        member.setMemberProperties(dict(must_change_password=0))
+        # uf.userSetPassword() may have updated some properties
+        updated_member = self.getValidUser(stored_user)
+        updated_member.setMemberProperties(dict(must_change_password=0))
 
         # clean out the request
         del self._requests[randomstring]


### PR DESCRIPTION
If any properties are added to the member object by plug-ins (such as `collective.pwexpiry`), the existing `member` in this context won’t have them and they won’t get committed.
