### PR TITLE
Remove unused fullname from ``mail_password_template.pt``

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,8 @@ Changelog
 2.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Remove unused attribute access of ``fullname`` (whereas it should have been access via ``getProperty``) on a PlonePAS MemberData object in ``mail_password_template.pt``, which lead to attribute access errors.
+  [thet]
 
 2.2.1 (2015-09-12)
 ------------------

--- a/Products/PasswordResetTool/skins/PasswordReset/mail_password_template.pt
+++ b/Products/PasswordResetTool/skins/PasswordReset/mail_password_template.pt
@@ -21,9 +21,7 @@ The site administrator asks you to reset your password for '<span i18n:name="use
 
 <div i18n:domain="passwordresettool"
      i18n:translate="mailtemplate_text_linkreset"
-     tal:omit-tag=""
-     tal:define="fullname python: test(member.fullname,
-                 ' %s'%member.fullname, '')">
+     tal:omit-tag="">
 The following link will take you to a page where you can reset your password for <span i18n:name="site_name"
           tal:omit-tag=""
           tal:content="portal_state/navigation_root_title" /> site:


### PR DESCRIPTION
Forward-port from the 2.0.x branch PR https://github.com/plone/Products.PasswordResetTool/pull/11/files

Remove unused attribute access of ``fullname`` (whereas it should have been access via ``getProperty``) on a PlonePAS MemberData object in ``mail_password_template.pt``, which lead to attribute access errors.