### PR TITLE
userid is cleaned by rstrip during password reset submission

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Sanitize `userid` that is coming from password reset form. That will be prevent error if user unintentionally provides username/email with whitespace.
+  [nazrulworld]
 
 
 2.2.3 (2016-08-18)

--- a/Products/PasswordResetTool/skins/PasswordReset/pwreset_action.cpy
+++ b/Products/PasswordResetTool/skins/PasswordReset/pwreset_action.cpy
@@ -12,6 +12,8 @@ from Products.PasswordResetTool.PasswordResetTool import InvalidRequestError, Ex
 status = "success"
 pw_tool = getToolByName(context, 'portal_password_reset')
 try:
+    # sanitization
+    userid = userid.rstrip()
     pw_tool.resetPassword(userid, randomstring, password)
 except ExpiredRequestError:
     status = "expired"

--- a/Products/PasswordResetTool/skins/PasswordReset/pwreset_action.cpy
+++ b/Products/PasswordResetTool/skins/PasswordReset/pwreset_action.cpy
@@ -13,7 +13,7 @@ status = "success"
 pw_tool = getToolByName(context, 'portal_password_reset')
 try:
     # sanitization
-    userid = userid.rstrip()
+    userid = userid.strip()
     pw_tool.resetPassword(userid, randomstring, password)
 except ExpiredRequestError:
     status = "expired"

--- a/Products/PasswordResetTool/skins/PasswordReset/pwreset_action.cpy
+++ b/Products/PasswordResetTool/skins/PasswordReset/pwreset_action.cpy
@@ -11,9 +11,9 @@ from Products.PasswordResetTool.PasswordResetTool import InvalidRequestError, Ex
 
 status = "success"
 pw_tool = getToolByName(context, 'portal_password_reset')
+# sanitization
+userid = userid.strip()
 try:
-    # sanitization
-    userid = userid.strip()
     pw_tool.resetPassword(userid, randomstring, password)
 except ExpiredRequestError:
     status = "expired"


### PR DESCRIPTION
There could be chance that user could copy his/her username with white space unintentionally. Thus I added a extra line for cleaning up. 